### PR TITLE
Enable selecting numbered patios when adding containers

### DIFF
--- a/my-app/components/container-management.tsx
+++ b/my-app/components/container-management.tsx
@@ -121,9 +121,11 @@ export function ContainerManagement() {
               <SelectValue placeholder="Seleccione el patio si el contenedor está disponible, en mantenimiento o en rancho" />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="patio-a">Patio A</SelectItem>
-              <SelectItem value="patio-b">Patio B</SelectItem>
-              <SelectItem value="patio-c">Patio C</SelectItem>
+              <SelectItem value="patio-1">PATIO 1</SelectItem>
+              <SelectItem value="patio-2">PATIO 2</SelectItem>
+              <SelectItem value="patio-3">PATIO 3</SelectItem>
+              <SelectItem value="patio-4">PATIO 4</SelectItem>
+              <SelectItem value="patio-5">PATIO 5</SelectItem>
             </SelectContent>
           </Select>
         </div>


### PR DESCRIPTION
## Summary
- allow choosing PATIO 1 through PATIO 5 for containers

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b8e3bf96d0833093f27e43d7f01743