### PR TITLE
feat: separar listado y creación de clientes

### DIFF
--- a/my-app/app/clientes/nuevo/page.tsx
+++ b/my-app/app/clientes/nuevo/page.tsx
@@ -1,21 +1,20 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { ClientForm } from "@/components/client-form"
 import { DashboardLayout } from "@/components/dashboard-layout"
-import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
 import { Users } from "lucide-react"
 
 export default function ClientesPage() {
   return (
-    <DashboardLayout breadcrumbs={["Clientes"]}>
-      <Card className="max-w-4xl">
+    <DashboardLayout breadcrumbs={["Clientes", "Añadir Cliente"]}>
+      <Card className="max-w-3xl">
         <CardHeader>
           <CardTitle className="text-2xl font-semibold flex items-center gap-3">
             <Users className="h-6 w-6 text-primary" />
-            Registro de Clientes
+            Añadir Cliente
           </CardTitle>
         </CardHeader>
         <CardContent>
-          <p className="text-muted-foreground">
-            Aquí se listarán todos los clientes agregados al sistema.
-          </p>
+          <ClientForm />
         </CardContent>
       </Card>
     </DashboardLayout>

--- a/my-app/components/dashboard-layout.tsx
+++ b/my-app/components/dashboard-layout.tsx
@@ -102,15 +102,23 @@ export function DashboardLayout({ children, breadcrumbs }: DashboardLayoutProps)
                     </div>
                     <span className="text-primary text-lg">+</span>
                   </Button>
-                  <Button asChild variant="ghost" className="w-full justify-between text-left">
-                    <Link href="/clientes" className="flex w-full items-center justify-between text-left">
-                      <div className="flex items-center gap-3">
+                  <div className="flex w-full items-center justify-between">
+                    <Button
+                      asChild
+                      variant="ghost"
+                      className="flex-1 justify-start text-left"
+                    >
+                      <Link href="/clientes" className="flex items-center gap-3">
                         <Users className="h-4 w-4" />
                         <span>Clientes</span>
-                      </div>
-                      <span className="text-primary text-lg">+</span>
-                    </Link>
-                  </Button>
+                      </Link>
+                    </Button>
+                    <Button asChild variant="ghost" className="text-primary px-2">
+                      <Link href="/clientes/nuevo">
+                        <span className="text-lg">+</span>
+                      </Link>
+                    </Button>
+                  </div>
                   <div className="flex w-full items-center justify-between">
                     <Button
                       asChild


### PR DESCRIPTION
## Summary
- add dedicated `/clientes` page to list registered clients
- move client creation form to `/clientes/nuevo`
- update dashboard sidebar to link to list and creation separately

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b8eb59541483309064290e68b1daea