### PR TITLE
feat: add rentals section

### DIFF
--- a/my-app/app/arrendamientos/nuevo/page.tsx
+++ b/my-app/app/arrendamientos/nuevo/page.tsx
@@ -1,0 +1,22 @@
+import { DashboardLayout } from "@/components/dashboard-layout"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { RentalForm } from "@/components/rental-form"
+import { Package } from "lucide-react"
+
+export default function NewRentalPage() {
+  return (
+    <DashboardLayout breadcrumbs={["Arrendamientos", "Añadir Arrendamiento"]}>
+      <Card className="max-w-3xl">
+        <CardHeader>
+          <CardTitle className="text-2xl font-semibold flex items-center gap-3">
+            <Package className="h-6 w-6 text-primary" />
+            Añadir Arrendamiento
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <RentalForm />
+        </CardContent>
+      </Card>
+    </DashboardLayout>
+  )
+}

--- a/my-app/app/arrendamientos/page.tsx
+++ b/my-app/app/arrendamientos/page.tsx
@@ -1,0 +1,23 @@
+import { DashboardLayout } from "@/components/dashboard-layout"
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
+import { Package } from "lucide-react"
+
+export default function ArrendamientosPage() {
+  return (
+    <DashboardLayout breadcrumbs={["Arrendamientos"]}>
+      <Card className="max-w-4xl">
+        <CardHeader>
+          <CardTitle className="text-2xl font-semibold flex items-center gap-3">
+            <Package className="h-6 w-6 text-primary" />
+            Registro de Arrendamientos
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-muted-foreground">
+            Aquí se listarán todos los arrendamientos agregados al sistema.
+          </p>
+        </CardContent>
+      </Card>
+    </DashboardLayout>
+  )
+}

--- a/my-app/components/dashboard-layout.tsx
+++ b/my-app/components/dashboard-layout.tsx
@@ -95,13 +95,23 @@ export function DashboardLayout({ children, breadcrumbs }: DashboardLayoutProps)
                   Contenedores
                 </h3>
                 <div className="space-y-1">
-                  <Button variant="ghost" className="w-full justify-between text-left">
-                    <div className="flex items-center gap-3">
-                      <Package className="h-4 w-4" />
-                      <span>Arrendamientos</span>
-                    </div>
-                    <span className="text-primary text-lg">+</span>
-                  </Button>
+                  <div className="flex w-full items-center justify-between">
+                    <Button
+                      asChild
+                      variant="ghost"
+                      className="flex-1 justify-start text-left"
+                    >
+                      <Link href="/arrendamientos" className="flex items-center gap-3">
+                        <Package className="h-4 w-4" />
+                        <span>Arrendamientos</span>
+                      </Link>
+                    </Button>
+                    <Button asChild variant="ghost" className="text-primary px-2">
+                      <Link href="/arrendamientos/nuevo">
+                        <span className="text-lg">+</span>
+                      </Link>
+                    </Button>
+                  </div>
                   <div className="flex w-full items-center justify-between">
                     <Button
                       asChild

--- a/my-app/components/rental-form.tsx
+++ b/my-app/components/rental-form.tsx
@@ -1,0 +1,122 @@
+"use client"
+
+import { useState } from "react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Calendar, Upload } from "lucide-react"
+
+export function RentalForm() {
+  const containers = ["Contenedor A", "Contenedor B"]
+  const clients = ["Cliente A", "Cliente B"]
+
+  const [formData, setFormData] = useState({
+    contenedor: "",
+    cliente: "",
+    fechaEntrega: "",
+    codigoGuia: "",
+    fechaRetiro: "",
+  })
+
+  const handleChange = (field: string, value: string) => {
+    setFormData((prev) => ({ ...prev, [field]: value }))
+  }
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault()
+    console.log("Nuevo arrendamiento", formData)
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <div className="space-y-2">
+          <Label htmlFor="contenedor">Contenedor</Label>
+          <Select value={formData.contenedor} onValueChange={(value) => handleChange("contenedor", value)}>
+            <SelectTrigger id="contenedor" className="bg-input">
+              <SelectValue placeholder="Seleccionar contenedor" />
+            </SelectTrigger>
+            <SelectContent>
+              {containers.map((c) => (
+                <SelectItem key={c} value={c}>
+                  {c}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="cliente">Cliente</Label>
+          <Select value={formData.cliente} onValueChange={(value) => handleChange("cliente", value)}>
+            <SelectTrigger id="cliente" className="bg-input">
+              <SelectValue placeholder="Seleccionar cliente" />
+            </SelectTrigger>
+            <SelectContent>
+              {clients.map((c) => (
+                <SelectItem key={c} value={c}>
+                  {c}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="fecha-entrega">Fecha de entrega</Label>
+          <div className="relative">
+            <Input
+              id="fecha-entrega"
+              type="date"
+              value={formData.fechaEntrega}
+              onChange={(e) => handleChange("fechaEntrega", e.target.value)}
+              className="bg-input"
+            />
+            <Calendar className="absolute right-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="codigo-guia">Código guía despacho</Label>
+          <Input
+            id="codigo-guia"
+            value={formData.codigoGuia}
+            onChange={(e) => handleChange("codigoGuia", e.target.value)}
+            className="bg-input"
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="fecha-retiro">Fecha de retiro</Label>
+          <div className="relative">
+            <Input
+              id="fecha-retiro"
+              type="date"
+              value={formData.fechaRetiro}
+              onChange={(e) => handleChange("fechaRetiro", e.target.value)}
+              className="bg-input"
+            />
+            <Calendar className="absolute right-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
+          </div>
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <Label className="text-sm font-medium">Ingresar factura (PDF)</Label>
+        <div className="flex items-center gap-2">
+          <Button variant="outline" size="sm" className="flex items-center gap-2 bg-transparent">
+            <Upload className="h-4 w-4" />
+            Seleccionar archivo
+          </Button>
+          <span className="text-sm text-muted-foreground">Sin archivos seleccionados</span>
+        </div>
+        <p className="text-xs text-muted-foreground">Subir factura en formato PDF</p>
+      </div>
+
+      <Button type="submit" className="bg-primary hover:bg-primary/90">
+        Guardar
+      </Button>
+    </form>
+  )
+}


### PR DESCRIPTION
## Summary
- add arrendamientos pages for listing and creation
- implement rental form with container, client, dates, dispatch code and PDF upload
- wire arrendamientos links into dashboard navigation

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b8ee2c615883309d141f48fabfa640