### PR TITLE
feat: display containers in table

### DIFF
--- a/my-app/app/contenedores/page.tsx
+++ b/my-app/app/contenedores/page.tsx
@@ -37,20 +37,38 @@ export default function ContainersPage() {
               No hay contenedores registrados.
             </p>
           ) : (
-            <ul className="divide-y">
-              {containers.map((c, index) => (
-                <li key={index} className="py-2">
-                  <div className="font-medium">
-                    {c.serieLetra}
-                    {c.numeroSerie} - {c.tipo}
-                  </div>
-                  <div className="text-sm text-muted-foreground">
-                    Estado: {c.estado}
-                    {c.patio ? ` | Patio: ${c.patio}` : ""}
-                  </div>
-                </li>
-              ))}
-            </ul>
+            <div className="overflow-x-auto">
+              <table className="min-w-full text-sm">
+                <thead>
+                  <tr className="border-b">
+                    <th className="py-2 px-3 text-left">Serie</th>
+                    <th className="py-2 px-3 text-left">Tipo</th>
+                    <th className="py-2 px-3 text-left">Estado</th>
+                    <th className="py-2 px-3 text-left">Patio</th>
+                    <th className="py-2 px-3 text-left">Proveedor</th>
+                    <th className="py-2 px-3 text-left">Nº Declaración</th>
+                    <th className="py-2 px-3 text-left">Fecha Declaración</th>
+                    <th className="py-2 px-3 text-left">Fecha Compra</th>
+                    <th className="py-2 px-3 text-left">Notas</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {containers.map((c, index) => (
+                    <tr key={index} className="border-b last:border-0">
+                      <td className="py-2 px-3 font-medium">{c.serieLetra}{c.numeroSerie}</td>
+                      <td className="py-2 px-3 capitalize">{c.tipo}</td>
+                      <td className="py-2 px-3">{c.estado}</td>
+                      <td className="py-2 px-3">{c.patio || "-"}</td>
+                      <td className="py-2 px-3">{c.proveedor || "-"}</td>
+                      <td className="py-2 px-3">{c.numeroDeclaracion || "-"}</td>
+                      <td className="py-2 px-3">{c.fechaDeclaracion || "-"}</td>
+                      <td className="py-2 px-3">{c.fechaCompra || "-"}</td>
+                      <td className="py-2 px-3 max-w-[200px] truncate">{c.notas || "-"}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
           )}
         </CardContent>
       </Card>


### PR DESCRIPTION
## Summary
- replace container registry list with detailed table

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9b17270908330aebb5d7488a27c0a