### PR TITLE
Add filters to container list

### DIFF
--- a/my-app/app/contenedores/page.tsx
+++ b/my-app/app/contenedores/page.tsx
@@ -3,6 +3,14 @@
 import { useEffect, useState } from "react"
 import { DashboardLayout } from "@/components/dashboard-layout"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 
 interface Container {
   serieLetra: string
@@ -19,11 +27,42 @@ interface Container {
 
 export default function ContainersPage() {
   const [containers, setContainers] = useState<Container[]>([])
+  const [estado, setEstado] = useState("")
+  const [tipo, setTipo] = useState("")
+  const [patio, setPatio] = useState("")
+  const [proveedor, setProveedor] = useState("")
+  const [fechaInicio, setFechaInicio] = useState("")
+  const [fechaFin, setFechaFin] = useState("")
+  const [busquedaSerie, setBusquedaSerie] = useState("")
 
   useEffect(() => {
     const stored = JSON.parse(localStorage.getItem("contenedores") || "[]")
     setContainers(stored)
   }, [])
+
+  const filteredContainers = containers.filter((c) => {
+    const matchesEstado = !estado || c.estado === estado
+    const matchesTipo = !tipo || c.tipo === tipo
+    const matchesPatio = !patio || c.patio === patio
+    const matchesProveedor =
+      !proveedor || c.proveedor?.toLowerCase().includes(proveedor.toLowerCase())
+    const serieCompleta = `${c.serieLetra}${c.numeroSerie}`.toLowerCase()
+    const matchesSerie =
+      !busquedaSerie || serieCompleta.includes(busquedaSerie.toLowerCase())
+    const fecha = c.fechaCompra ? new Date(c.fechaCompra) : null
+    const matchesFechaInicio =
+      !fechaInicio || (fecha && new Date(fechaInicio) <= fecha)
+    const matchesFechaFin = !fechaFin || (fecha && new Date(fechaFin) >= fecha)
+    return (
+      matchesEstado &&
+      matchesTipo &&
+      matchesPatio &&
+      matchesProveedor &&
+      matchesSerie &&
+      matchesFechaInicio &&
+      matchesFechaFin
+    )
+  })
 
   return (
     <DashboardLayout breadcrumbs={["Contenedores"]}>
@@ -32,7 +71,72 @@ export default function ContainersPage() {
           <CardTitle className="text-2xl font-semibold">Registro de Contenedores</CardTitle>
         </CardHeader>
         <CardContent>
-          {containers.length === 0 ? (
+          <div className="flex flex-wrap gap-2 mb-4">
+            <Input
+              placeholder="Buscar serie"
+              value={busquedaSerie}
+              onChange={(e) => setBusquedaSerie(e.target.value)}
+              className="w-[150px]"
+            />
+            <Select value={estado} onValueChange={setEstado}>
+              <SelectTrigger className="w-[140px]">
+                <SelectValue placeholder="Estado" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="Disponible">Disponible</SelectItem>
+                <SelectItem value="Arrendado">Arrendado</SelectItem>
+                <SelectItem value="Mantenimiento">Mantenimiento</SelectItem>
+              </SelectContent>
+            </Select>
+            <Select value={tipo} onValueChange={setTipo}>
+              <SelectTrigger className="w-[160px]">
+                <SelectValue placeholder="Tipo" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="banos">BAÑOS</SelectItem>
+                <SelectItem value="duchas">DUCHAS</SelectItem>
+                <SelectItem value="oficina">OFICINA</SelectItem>
+                <SelectItem value="ofic-bano">OFIC/BAÑO</SelectItem>
+                <SelectItem value="ofic-dormitorio">OFIC/DORMITORIO</SelectItem>
+                <SelectItem value="ofic-separ">OFIC/SEPAR</SelectItem>
+                <SelectItem value="bodega-40">BODEGA 40</SelectItem>
+                <SelectItem value="bodega-50">BODEGA 50%</SelectItem>
+                <SelectItem value="bod-estan">BOD/ESTAN</SelectItem>
+                <SelectItem value="bod-art-pel">BOD ART PEL</SelectItem>
+                <SelectItem value="sala-cambio">SALA CAMBIO</SelectItem>
+                <SelectItem value="bod-estanque">BOD/ESTANQUE</SelectItem>
+              </SelectContent>
+            </Select>
+            <Select value={patio} onValueChange={setPatio}>
+              <SelectTrigger className="w-[140px]">
+                <SelectValue placeholder="Patio" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="patio-1">PATIO 1</SelectItem>
+                <SelectItem value="patio-2">PATIO 2</SelectItem>
+                <SelectItem value="patio-3">PATIO 3</SelectItem>
+                <SelectItem value="patio-4">PATIO 4</SelectItem>
+                <SelectItem value="patio-5">PATIO 5</SelectItem>
+              </SelectContent>
+            </Select>
+            <Input
+              placeholder="Proveedor"
+              value={proveedor}
+              onChange={(e) => setProveedor(e.target.value)}
+              className="w-[150px]"
+            />
+            <Input
+              type="date"
+              value={fechaInicio}
+              onChange={(e) => setFechaInicio(e.target.value)}
+            />
+            <Input
+              type="date"
+              value={fechaFin}
+              onChange={(e) => setFechaFin(e.target.value)}
+            />
+          </div>
+          {filteredContainers.length === 0 ? (
             <p className="text-muted-foreground">
               No hay contenedores registrados.
             </p>
@@ -53,7 +157,7 @@ export default function ContainersPage() {
                   </tr>
                 </thead>
                 <tbody>
-                  {containers.map((c, index) => (
+                  {filteredContainers.map((c, index) => (
                     <tr key={index} className="border-b last:border-0">
                       <td className="py-2 px-3 font-medium">{c.serieLetra}{c.numeroSerie}</td>
                       <td className="py-2 px-3 capitalize">{c.tipo}</td>


### PR DESCRIPTION
## Summary
- allow filtering containers by estado, tipo, patio, proveedor, date range, and series text
- add filter controls (text, select and date inputs) above the table

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9bbb99aa483308f4e77a2ebb773f8