### PR TITLE
Populate rental client selector from registry

### DIFF
--- a/my-app/app/clientes/page.tsx
+++ b/my-app/app/clientes/page.tsx
@@ -1,8 +1,28 @@
+"use client"
+
+import { useEffect, useState } from "react"
 import { DashboardLayout } from "@/components/dashboard-layout"
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
 import { Users } from "lucide-react"
 
+interface Client {
+  nombre: string
+  tipo: string
+  documento: string
+  email: string
+  telefono: string
+  contacto: string
+  ciudad: string
+}
+
 export default function ClientesPage() {
+  const [clients, setClients] = useState<Client[]>([])
+
+  useEffect(() => {
+    const stored = JSON.parse(localStorage.getItem("clientes") || "[]")
+    setClients(stored)
+  }, [])
+
   return (
     <DashboardLayout breadcrumbs={["Clientes"]}>
       <Card className="max-w-4xl">
@@ -13,9 +33,40 @@ export default function ClientesPage() {
           </CardTitle>
         </CardHeader>
         <CardContent>
-          <p className="text-muted-foreground">
-            Aquí se listarán todos los clientes agregados al sistema.
-          </p>
+          {clients.length === 0 ? (
+            <p className="text-muted-foreground">
+              No hay clientes registrados.
+            </p>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="min-w-full text-sm">
+                <thead>
+                  <tr className="border-b">
+                    <th className="py-2 px-3 text-left">Nombre</th>
+                    <th className="py-2 px-3 text-left">Tipo</th>
+                    <th className="py-2 px-3 text-left">Documento</th>
+                    <th className="py-2 px-3 text-left">Email</th>
+                    <th className="py-2 px-3 text-left">Teléfono</th>
+                    <th className="py-2 px-3 text-left">Contacto</th>
+                    <th className="py-2 px-3 text-left">Ciudad</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {clients.map((c, index) => (
+                    <tr key={index} className="border-b last:border-0">
+                      <td className="py-2 px-3 font-medium">{c.nombre}</td>
+                      <td className="py-2 px-3 capitalize">{c.tipo}</td>
+                      <td className="py-2 px-3">{c.documento || "-"}</td>
+                      <td className="py-2 px-3">{c.email || "-"}</td>
+                      <td className="py-2 px-3">{c.telefono || "-"}</td>
+                      <td className="py-2 px-3">{c.contacto || "-"}</td>
+                      <td className="py-2 px-3">{c.ciudad || "-"}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
         </CardContent>
       </Card>
     </DashboardLayout>

--- a/my-app/components/client-form.tsx
+++ b/my-app/components/client-form.tsx
@@ -23,7 +23,18 @@ export function ClientForm() {
 
   const handleSubmit = (event: React.FormEvent) => {
     event.preventDefault()
-    console.log(formData)
+    const stored = JSON.parse(localStorage.getItem("clientes") || "[]")
+    stored.push(formData)
+    localStorage.setItem("clientes", JSON.stringify(stored))
+    setFormData({
+      nombre: "",
+      tipo: "",
+      documento: "",
+      email: "",
+      telefono: "",
+      contacto: "",
+      ciudad: "",
+    })
   }
 
   return (

--- a/my-app/components/rental-form.tsx
+++ b/my-app/components/rental-form.tsx
@@ -15,11 +15,16 @@ interface Container {
 
 export function RentalForm() {
   const [containers, setContainers] = useState<Container[]>([])
-  const clients = ["Cliente A", "Cliente B"]
+  interface Client {
+    nombre: string
+  }
+  const [clients, setClients] = useState<Client[]>([])
 
   useEffect(() => {
     const stored = JSON.parse(localStorage.getItem("contenedores") || "[]")
     setContainers(stored)
+    const storedClients = JSON.parse(localStorage.getItem("clientes") || "[]")
+    setClients(storedClients)
   }, [])
 
   const [formData, setFormData] = useState({
@@ -90,16 +95,30 @@ export function RentalForm() {
 
         <div className="space-y-2">
           <Label htmlFor="cliente">Cliente</Label>
-          <Select value={formData.cliente} onValueChange={(value) => handleChange("cliente", value)}>
-            <SelectTrigger id="cliente" className="bg-input">
-              <SelectValue placeholder="Seleccionar cliente" />
+          <Select
+            value={formData.cliente}
+            onValueChange={(value) => handleChange("cliente", value)}
+            disabled={clients.length === 0}
+          >
+            <SelectTrigger id="cliente" className="bg-input" disabled={clients.length === 0}>
+              <SelectValue
+                placeholder={
+                  clients.length ? "Seleccionar cliente" : "No hay clientes registrados"
+                }
+              />
             </SelectTrigger>
             <SelectContent>
-              {clients.map((c) => (
-                <SelectItem key={c} value={c}>
-                  {c}
+              {clients.length ? (
+                clients.map((c, index) => (
+                  <SelectItem key={index} value={c.nombre}>
+                    {c.nombre}
+                  </SelectItem>
+                ))
+              ) : (
+                <SelectItem value="" disabled>
+                  No hay clientes registrados
                 </SelectItem>
-              ))}
+              )}
             </SelectContent>
           </Select>
         </div>


### PR DESCRIPTION
## Summary
- Persist client registrations to localStorage and display them in the client list
- Load stored clients into the rental creation form for selection

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9ddd6a6208330985f5416157572ba