### PR TITLE
Permitir carga y visualización de PDFs en contenedores

### DIFF
--- a/my-app/app/contenedores/page.tsx
+++ b/my-app/app/contenedores/page.tsx
@@ -12,6 +12,11 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 
+interface FileData {
+  name: string
+  data: string
+}
+
 interface Container {
   serieLetra: string
   numeroSerie: string
@@ -23,6 +28,8 @@ interface Container {
   fechaDeclaracion: string
   fechaCompra: string
   notas: string
+  facturaPDF?: FileData | null
+  declaracionPDF?: FileData | null
 }
 
 export default function ContainersPage() {
@@ -156,6 +163,8 @@ export default function ContainersPage() {
                     <th className="py-2 px-3 text-left">Nº Declaración</th>
                     <th className="py-2 px-3 text-left">Fecha Declaración</th>
                     <th className="py-2 px-3 text-left">Fecha Compra</th>
+                    <th className="py-2 px-3 text-left">Factura PDF</th>
+                    <th className="py-2 px-3 text-left">Declaración PDF</th>
                     <th className="py-2 px-3 text-left">Notas</th>
                   </tr>
                 </thead>
@@ -170,6 +179,34 @@ export default function ContainersPage() {
                       <td className="py-2 px-3">{c.numeroDeclaracion || "-"}</td>
                       <td className="py-2 px-3">{c.fechaDeclaracion || "-"}</td>
                       <td className="py-2 px-3">{c.fechaCompra || "-"}</td>
+                      <td className="py-2 px-3">
+                        {c.facturaPDF ? (
+                          <a
+                            href={c.facturaPDF.data}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-primary underline"
+                          >
+                            Ver
+                          </a>
+                        ) : (
+                          "-"
+                        )}
+                      </td>
+                      <td className="py-2 px-3">
+                        {c.declaracionPDF ? (
+                          <a
+                            href={c.declaracionPDF.data}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-primary underline"
+                          >
+                            Ver
+                          </a>
+                        ) : (
+                          "-"
+                        )}
+                      </td>
                       <td className="py-2 px-3 max-w-[200px] truncate">{c.notas || "-"}</td>
                     </tr>
                   ))}

--- a/my-app/components/container-management.tsx
+++ b/my-app/components/container-management.tsx
@@ -11,8 +11,28 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { DashboardLayout } from "@/components/dashboard-layout"
 import { Calendar, Upload, Container, FileText } from "lucide-react"
 
+interface FileData {
+  name: string
+  data: string
+}
+
+interface ContainerFormData {
+  serieLetra: string
+  numeroSerie: string
+  tipo: string
+  estado: string
+  patio: string
+  proveedor: string
+  numeroDeclaracion: string
+  fechaDeclaracion: string
+  fechaCompra: string
+  notas: string
+  facturaPDF: FileData | null
+  declaracionPDF: FileData | null
+}
+
 export function ContainerManagement() {
-  const [formData, setFormData] = useState({
+  const [formData, setFormData] = useState<ContainerFormData>({
     serieLetra: "",
     numeroSerie: "",
     tipo: "",
@@ -23,6 +43,8 @@ export function ContainerManagement() {
     fechaDeclaracion: "",
     fechaCompra: "",
     notas: "",
+    facturaPDF: null,
+    declaracionPDF: null,
   })
 
   const router = useRouter()
@@ -37,6 +59,24 @@ export function ContainerManagement() {
       estado: value,
       patio: value === "Arrendado" ? "" : prev.patio,
     }))
+  }
+
+  const handleFileChange = (
+    field: "facturaPDF" | "declaracionPDF",
+    file: File | null,
+  ) => {
+    if (file) {
+      const reader = new FileReader()
+      reader.onload = () => {
+        setFormData((prev) => ({
+          ...prev,
+          [field]: { name: file.name, data: reader.result as string },
+        }))
+      }
+      reader.readAsDataURL(file)
+    } else {
+      setFormData((prev) => ({ ...prev, [field]: null }))
+    }
   }
 
   const handleSubmit = (event: React.FormEvent) => {
@@ -219,13 +259,45 @@ export function ContainerManagement() {
           <div className="space-y-2">
             <Label className="text-sm font-medium">Declaración de Importación (PDF)</Label>
             <div className="flex items-center gap-2">
-              <Button variant="outline" size="sm" className="flex items-center gap-2 bg-transparent">
-                <Upload className="h-4 w-4" />
-                Seleccionar archivo
-              </Button>
-              <span className="text-sm text-muted-foreground">Sin archivos seleccionados</span>
+              <Input
+                id="declaracion-pdf"
+                type="file"
+                accept="application/pdf"
+                onChange={(e) =>
+                  handleFileChange(
+                    "declaracionPDF",
+                    e.target.files?.[0] || null,
+                  )
+                }
+                className="hidden"
+              />
+              <Label htmlFor="declaracion-pdf">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="flex items-center gap-2 bg-transparent"
+                >
+                  <Upload className="h-4 w-4" />
+                  Seleccionar archivo
+                </Button>
+              </Label>
+              <span className="text-sm text-muted-foreground">
+                {formData.declaracionPDF?.name || "Sin archivos seleccionados"}
+              </span>
             </div>
-            <p className="text-xs text-muted-foreground">Subir la Declaración de Importación en PDF</p>
+            {formData.declaracionPDF && (
+              <a
+                href={formData.declaracionPDF.data}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-xs text-primary underline"
+              >
+                Ver archivo
+              </a>
+            )}
+            <p className="text-xs text-muted-foreground">
+              Subir la Declaración de Importación en PDF
+            </p>
           </div>
 
           <div className="space-y-2">
@@ -242,48 +314,50 @@ export function ContainerManagement() {
               />
               <Calendar className="absolute right-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
             </div>
-            <p className="text-xs text-muted-foreground">Fecha en que se compró el contenedor</p>
+            <p className="text-xs text-muted-foreground">
+              Fecha en que se compró el contenedor
+            </p>
           </div>
-        </div>
 
-        {/* File Upload Section */}
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
           <div className="space-y-2">
             <Label className="text-sm font-medium">Ingresar factura (PDF)</Label>
             <div className="flex items-center gap-2">
-              <Button variant="outline" size="sm" className="flex items-center gap-2 bg-transparent">
-                <Upload className="h-4 w-4" />
-                Seleccionar archivo
-              </Button>
-              <span className="text-sm text-muted-foreground">Sin archivos seleccionados</span>
+              <Input
+                id="factura-pdf"
+                type="file"
+                accept="application/pdf"
+                onChange={(e) =>
+                  handleFileChange("facturaPDF", e.target.files?.[0] || null)
+                }
+                className="hidden"
+              />
+              <Label htmlFor="factura-pdf">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="flex items-center gap-2 bg-transparent"
+                >
+                  <Upload className="h-4 w-4" />
+                  Seleccionar archivo
+                </Button>
+              </Label>
+              <span className="text-sm text-muted-foreground">
+                {formData.facturaPDF?.name || "Sin archivos seleccionados"}
+              </span>
             </div>
-            <p className="text-xs text-muted-foreground">Subir factura de compra en formato PDF</p>
-          </div>
-
-          <div className="space-y-4">
-            <div className="space-y-2">
-              <Label className="text-sm font-medium">Factura PDF</Label>
-              <Select>
-                <SelectTrigger className="bg-input">
-                  <SelectValue placeholder="---------" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="none">Sin archivo</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-
-            <div className="space-y-2">
-              <Label className="text-sm font-medium">Declaración PDF</Label>
-              <Select>
-                <SelectTrigger className="bg-input">
-                  <SelectValue placeholder="---------" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="none">Sin archivo</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
+            {formData.facturaPDF && (
+              <a
+                href={formData.facturaPDF.data}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-xs text-primary underline"
+              >
+                Ver archivo
+              </a>
+            )}
+            <p className="text-xs text-muted-foreground">
+              Subir factura de compra en formato PDF
+            </p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Allow uploading PDF files for import declaration and purchase invoice when adding a container
- Persist PDF data within container records and show links to view them in the container list

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Geist` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68bba1512cb88330aaf2b34249a65ee6