### PR TITLE
feat: add invoice upload for rentals

### DIFF
--- a/my-app/app/arriendos/page.tsx
+++ b/my-app/app/arriendos/page.tsx
@@ -1,8 +1,28 @@
+"use client"
+
+import { useEffect, useState } from "react"
 import { DashboardLayout } from "@/components/dashboard-layout"
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
 import { Package } from "lucide-react"
 
+interface Rental {
+  contenedor: string
+  cliente: string
+  fechaEntrega: string
+  codigoGuia: string
+  fechaRetiro: string
+  facturaNombre: string
+  facturaArchivo: string
+}
+
 export default function ArriendosPage() {
+  const [rentals, setRentals] = useState<Rental[]>([])
+
+  useEffect(() => {
+    const stored = JSON.parse(localStorage.getItem("arriendos") || "[]")
+    setRentals(stored)
+  }, [])
+
   return (
     <DashboardLayout breadcrumbs={["Arriendos"]}>
       <Card className="max-w-4xl">
@@ -13,9 +33,50 @@ export default function ArriendosPage() {
           </CardTitle>
         </CardHeader>
         <CardContent>
-          <p className="text-muted-foreground">
-            Aquí se listarán todos los arriendos agregados al sistema.
-          </p>
+          {rentals.length ? (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="text-left border-b">
+                    <th className="p-2">Contenedor</th>
+                    <th className="p-2">Cliente</th>
+                    <th className="p-2">Fecha entrega</th>
+                    <th className="p-2">Código guía</th>
+                    <th className="p-2">Fecha retiro</th>
+                    <th className="p-2">Factura</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {rentals.map((r, i) => (
+                    <tr key={i} className="border-b last:border-0">
+                      <td className="p-2">{r.contenedor}</td>
+                      <td className="p-2">{r.cliente}</td>
+                      <td className="p-2">{r.fechaEntrega}</td>
+                      <td className="p-2">{r.codigoGuia}</td>
+                      <td className="p-2">{r.fechaRetiro}</td>
+                      <td className="p-2">
+                        {r.facturaArchivo ? (
+                          <a
+                            href={r.facturaArchivo}
+                            download={r.facturaNombre}
+                            className="text-primary underline"
+                          >
+                            Descargar
+                          </a>
+                        ) : (
+                          "-"
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : (
+            <p className="text-muted-foreground">
+              Aquí se listarán todos los arriendos agregados al sistema.
+            </p>
+          )}
         </CardContent>
       </Card>
     </DashboardLayout>


### PR DESCRIPTION
## Summary
- allow uploading PDF invoice when creating rental and persist file in localStorage
- list rentals and provide download link for stored invoice

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68bba1aeb2e48330bc0fdde634e654ac