### PR TITLE
Prevent auto-submit on PDF selection

### DIFF
--- a/my-app/components/container-management.tsx
+++ b/my-app/components/container-management.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useRef } from "react"
 import { useRouter } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -24,6 +24,11 @@ export function ContainerManagement() {
     fechaCompra: "",
     notas: "",
   })
+
+  const [declaracionFile, setDeclaracionFile] = useState<File | null>(null)
+  const [facturaFile, setFacturaFile] = useState<File | null>(null)
+  const declaracionInputRef = useRef<HTMLInputElement>(null)
+  const facturaInputRef = useRef<HTMLInputElement>(null)
 
   const router = useRouter()
 
@@ -218,12 +223,27 @@ export function ContainerManagement() {
 
           <div className="space-y-2">
             <Label className="text-sm font-medium">Declaración de Importación (PDF)</Label>
+            <input
+              type="file"
+              accept="application/pdf"
+              ref={declaracionInputRef}
+              onChange={(e) => setDeclaracionFile(e.target.files?.[0] || null)}
+              className="hidden"
+            />
             <div className="flex items-center gap-2">
-              <Button variant="outline" size="sm" className="flex items-center gap-2 bg-transparent">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="flex items-center gap-2 bg-transparent"
+                onClick={() => declaracionInputRef.current?.click()}
+              >
                 <Upload className="h-4 w-4" />
                 Seleccionar archivo
               </Button>
-              <span className="text-sm text-muted-foreground">Sin archivos seleccionados</span>
+              <span className="text-sm text-muted-foreground">
+                {declaracionFile ? declaracionFile.name : "Sin archivos seleccionados"}
+              </span>
             </div>
             <p className="text-xs text-muted-foreground">Subir la Declaración de Importación en PDF</p>
           </div>
@@ -250,12 +270,27 @@ export function ContainerManagement() {
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
           <div className="space-y-2">
             <Label className="text-sm font-medium">Ingresar factura (PDF)</Label>
+            <input
+              type="file"
+              accept="application/pdf"
+              ref={facturaInputRef}
+              onChange={(e) => setFacturaFile(e.target.files?.[0] || null)}
+              className="hidden"
+            />
             <div className="flex items-center gap-2">
-              <Button variant="outline" size="sm" className="flex items-center gap-2 bg-transparent">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="flex items-center gap-2 bg-transparent"
+                onClick={() => facturaInputRef.current?.click()}
+              >
                 <Upload className="h-4 w-4" />
                 Seleccionar archivo
               </Button>
-              <span className="text-sm text-muted-foreground">Sin archivos seleccionados</span>
+              <span className="text-sm text-muted-foreground">
+                {facturaFile ? facturaFile.name : "Sin archivos seleccionados"}
+              </span>
             </div>
             <p className="text-xs text-muted-foreground">Subir factura de compra en formato PDF</p>
           </div>

--- a/my-app/components/rental-form.tsx
+++ b/my-app/components/rental-form.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useState } from "react"
+import { useEffect, useState, useRef } from "react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
@@ -29,6 +29,9 @@ export function RentalForm() {
     codigoGuia: "",
     fechaRetiro: "",
   })
+
+  const [facturaFile, setFacturaFile] = useState<File | null>(null)
+  const facturaInputRef = useRef<HTMLInputElement>(null)
 
   const handleChange = (field: string, value: string) => {
     setFormData((prev) => ({ ...prev, [field]: value }))
@@ -145,12 +148,27 @@ export function RentalForm() {
 
       <div className="space-y-2">
         <Label className="text-sm font-medium">Ingresar factura (PDF)</Label>
+        <input
+          type="file"
+          accept="application/pdf"
+          ref={facturaInputRef}
+          onChange={(e) => setFacturaFile(e.target.files?.[0] || null)}
+          className="hidden"
+        />
         <div className="flex items-center gap-2">
-          <Button variant="outline" size="sm" className="flex items-center gap-2 bg-transparent">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="flex items-center gap-2 bg-transparent"
+            onClick={() => facturaInputRef.current?.click()}
+          >
             <Upload className="h-4 w-4" />
             Seleccionar archivo
           </Button>
-          <span className="text-sm text-muted-foreground">Sin archivos seleccionados</span>
+          <span className="text-sm text-muted-foreground">
+            {facturaFile ? facturaFile.name : "Sin archivos seleccionados"}
+          </span>
         </div>
         <p className="text-xs text-muted-foreground">Subir factura en formato PDF</p>
       </div>


### PR DESCRIPTION
## Summary
- allow selecting import declaration and invoice PDFs without submitting the form
- show chosen filenames and add hidden inputs for upload
- apply same fix to rental form to avoid accidental submissions

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bba9b386148330a5866f1aa7a73a47