### PR TITLE
Add Rancho container status

### DIFF
--- a/my-app/app/contenedores/page.tsx
+++ b/my-app/app/contenedores/page.tsx
@@ -87,6 +87,7 @@ export default function ContainersPage() {
                 <SelectItem value="Disponible">Disponible</SelectItem>
                 <SelectItem value="Arrendado">Arrendado</SelectItem>
                 <SelectItem value="Mantenimiento">Mantenimiento</SelectItem>
+                <SelectItem value="Rancho">Rancho</SelectItem>
               </SelectContent>
             </Select>
             <Select value={tipo} onValueChange={setTipo}>

--- a/my-app/components/container-management.tsx
+++ b/my-app/components/container-management.tsx
@@ -42,9 +42,12 @@ export function ContainerManagement() {
   const handleSubmit = (event: React.FormEvent) => {
     event.preventDefault()
     const { estado, patio } = formData
-    const requiresPatio = estado === "Disponible" || estado === "Mantenimiento"
+    const requiresPatio =
+      estado === "Disponible" || estado === "Mantenimiento" || estado === "Rancho"
     if (requiresPatio && !patio) {
-      alert("Debe seleccionar un patio cuando el contenedor está Disponible o en Mantenimiento")
+      alert(
+        "Debe seleccionar un patio cuando el contenedor está Disponible, en Mantenimiento o en Rancho",
+      )
       return
     }
     if (estado === "Arrendado" && patio) {
@@ -137,6 +140,7 @@ export function ContainerManagement() {
               <SelectItem value="Disponible">Disponible</SelectItem>
               <SelectItem value="Arrendado">Arrendado</SelectItem>
               <SelectItem value="Mantenimiento">Mantenimiento</SelectItem>
+              <SelectItem value="Rancho">Rancho</SelectItem>
             </SelectContent>
           </Select>
         </div>
@@ -152,7 +156,7 @@ export function ContainerManagement() {
             disabled={formData.estado === "Arrendado"}
           >
             <SelectTrigger className="bg-input" disabled={formData.estado === "Arrendado"}>
-              <SelectValue placeholder="Seleccione el patio si el contenedor está disponible o en mantenimiento" />
+              <SelectValue placeholder="Seleccione el patio si el contenedor está disponible, en mantenimiento o en Rancho" />
             </SelectTrigger>
             <SelectContent>
               <SelectItem value="patio-1">PATIO 1</SelectItem>


### PR DESCRIPTION
## Summary
- allow choosing new Rancho status when adding containers
- require patio selection for Disponible, Mantenimiento and Rancho
- filter contenedores list by Rancho status

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bba283db488330a4865c711f2fba32