### PR TITLE
feat: show locally stored clients in registry

### DIFF
--- a/my-app/app/clientes/page.tsx
+++ b/my-app/app/clientes/page.tsx
@@ -1,8 +1,9 @@
+"use client"
+
+import { useEffect, useState } from "react"
 import { DashboardLayout } from "@/components/dashboard-layout"
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
 import { Users } from "lucide-react"
-import { promises as fs } from "fs"
-import path from "path"
 
 type Cliente = {
   id: number
@@ -15,12 +16,15 @@ type Cliente = {
   ciudad: string
 }
 
-export const dynamic = "force-dynamic"
+export default function ClientesPage() {
+  const [clientes, setClientes] = useState<Cliente[]>([])
 
-export default async function ClientesPage() {
-  const filePath = path.join(process.cwd(), "data", "clientes.json")
-  const data = await fs.readFile(filePath, "utf-8")
-  const clientes: Cliente[] = JSON.parse(data)
+  useEffect(() => {
+    const stored = localStorage.getItem("clientes")
+    if (stored) {
+      setClientes(JSON.parse(stored))
+    }
+  }, [])
 
   return (
     <DashboardLayout breadcrumbs={["Clientes"]}>

--- a/my-app/components/client-form.tsx
+++ b/my-app/components/client-form.tsx
@@ -24,13 +24,11 @@ export function ClientForm() {
 
   const router = useRouter()
 
-  const handleSubmit = async (event: React.FormEvent) => {
+  const handleSubmit = (event: React.FormEvent) => {
     event.preventDefault()
-    await fetch("/api/clientes", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(formData),
-    })
+    const existing = JSON.parse(localStorage.getItem("clientes") || "[]")
+    const newClient = { id: Date.now(), ...formData }
+    localStorage.setItem("clientes", JSON.stringify([...existing, newClient]))
     router.push("/clientes")
   }
 


### PR DESCRIPTION
## Summary
- store new clients in browser localStorage instead of calling API
- load clients from localStorage on the registry page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Geist` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68bcc35d6bb48330afd6fa32b9bb876e