### PR TITLE
Manejo seguro de contenedores en localStorage

### DIFF
--- a/my-app/app/contenedores/page.tsx
+++ b/my-app/app/contenedores/page.tsx
@@ -36,8 +36,15 @@ export default function ContainersPage() {
   const [busquedaSerie, setBusquedaSerie] = useState("")
 
   useEffect(() => {
-    const stored = JSON.parse(localStorage.getItem("contenedores") || "[]")
-    setContainers(stored)
+    try {
+      const stored = JSON.parse(localStorage.getItem("contenedores") || "[]")
+      setContainers(stored)
+    } catch (error) {
+      if (error instanceof SyntaxError) {
+        alert("Los datos de contenedores están corruptos. Se mostrará una lista vacía.")
+        setContainers([])
+      }
+    }
   }, [])
 
   const filteredContainers = containers.filter((c) => {

--- a/my-app/components/container-management.tsx
+++ b/my-app/components/container-management.tsx
@@ -11,8 +11,21 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { DashboardLayout } from "@/components/dashboard-layout"
 import { Calendar, Upload, Container, FileText } from "lucide-react"
 
+interface ContainerFormData {
+  serieLetra: string
+  numeroSerie: string
+  tipo: string
+  estado: string
+  patio: string
+  proveedor: string
+  numeroDeclaracion: string
+  fechaDeclaracion: string
+  fechaCompra: string
+  notas: string
+}
+
 export function ContainerManagement() {
-  const [formData, setFormData] = useState({
+  const [formData, setFormData] = useState<ContainerFormData>({
     serieLetra: "",
     numeroSerie: "",
     tipo: "",
@@ -60,7 +73,17 @@ export function ContainerManagement() {
       return
     }
 
-    const stored = JSON.parse(localStorage.getItem("contenedores") || "[]")
+    let stored: ContainerFormData[] = []
+    try {
+      stored = JSON.parse(localStorage.getItem("contenedores") || "[]")
+    } catch (error) {
+      if (error instanceof SyntaxError) {
+        alert(
+          "Los datos de contenedores están corruptos. Se reiniciará el registro.",
+        )
+        stored = []
+      }
+    }
     stored.push(formData)
     localStorage.setItem("contenedores", JSON.stringify(stored))
     router.push("/contenedores")

--- a/my-app/components/rental-form.tsx
+++ b/my-app/components/rental-form.tsx
@@ -18,8 +18,15 @@ export function RentalForm() {
   const clients = ["Cliente A", "Cliente B"]
 
   useEffect(() => {
-    const stored = JSON.parse(localStorage.getItem("contenedores") || "[]")
-    setContainers(stored)
+    try {
+      const stored = JSON.parse(localStorage.getItem("contenedores") || "[]")
+      setContainers(stored)
+    } catch (error) {
+      if (error instanceof SyntaxError) {
+        alert("Error al leer los contenedores almacenados.")
+        setContainers([])
+      }
+    }
   }, [])
 
   const [formData, setFormData] = useState({


### PR DESCRIPTION
## Resumen
- Maneja errores de parseo al leer contenedores desde `localStorage` en formularios y páginas.
- Inicializa con un arreglo vacío y muestra aviso cuando los datos están corruptos.
- Define tipos estrictos para la gestión de contenedores y evita el uso de `any`.

## Testing
- `npm test` *(falla: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bcc6523e3c83309e3583c35269bd9d