### PR TITLE
Add validation for contenedor localStorage data

### DIFF
--- a/my-app/app/contenedores/page.tsx
+++ b/my-app/app/contenedores/page.tsx
@@ -38,12 +38,17 @@ export default function ContainersPage() {
   useEffect(() => {
     try {
       const stored = JSON.parse(localStorage.getItem("contenedores") || "[]")
-      setContainers(stored)
-    } catch (error) {
-      if (error instanceof SyntaxError) {
+      if (Array.isArray(stored)) {
+        setContainers(stored)
+      } else {
         alert("Los datos de contenedores están corruptos. Se mostrará una lista vacía.")
         setContainers([])
       }
+    } catch (error) {
+      if (error instanceof SyntaxError) {
+        alert("Los datos de contenedores están corruptos. Se mostrará una lista vacía.")
+      }
+      setContainers([])
     }
   }, [])
 

--- a/my-app/components/container-management.tsx
+++ b/my-app/components/container-management.tsx
@@ -75,14 +75,22 @@ export function ContainerManagement() {
 
     let stored: ContainerFormData[] = []
     try {
-      stored = JSON.parse(localStorage.getItem("contenedores") || "[]")
-    } catch (error) {
-      if (error instanceof SyntaxError) {
+      const parsed = JSON.parse(localStorage.getItem("contenedores") || "[]")
+      if (Array.isArray(parsed)) {
+        stored = parsed
+      } else {
         alert(
           "Los datos de contenedores están corruptos. Se reiniciará el registro.",
         )
         stored = []
       }
+    } catch (error) {
+      if (error instanceof SyntaxError) {
+        alert(
+          "Los datos de contenedores están corruptos. Se reiniciará el registro.",
+        )
+      }
+      stored = []
     }
     stored.push(formData)
     localStorage.setItem("contenedores", JSON.stringify(stored))

--- a/my-app/components/rental-form.tsx
+++ b/my-app/components/rental-form.tsx
@@ -20,12 +20,17 @@ export function RentalForm() {
   useEffect(() => {
     try {
       const stored = JSON.parse(localStorage.getItem("contenedores") || "[]")
-      setContainers(stored)
+      if (Array.isArray(stored)) {
+        setContainers(stored)
+      } else {
+        alert("Los datos de contenedores están corruptos. Se mostrará una lista vacía.")
+        setContainers([])
+      }
     } catch (error) {
       if (error instanceof SyntaxError) {
         alert("Error al leer los contenedores almacenados.")
-        setContainers([])
       }
+      setContainers([])
     }
   }, [])
 


### PR DESCRIPTION
## Summary
- guard against corrupt `contenedores` data by validating that parsed localStorage values are arrays in the rental form
- apply the same array validation to containers page and container management component

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7103b92548330a2a0343596545b25