### PR TITLE
Add container editing and deletion

### DIFF
--- a/my-app/app/contenedores/[index]/page.tsx
+++ b/my-app/app/contenedores/[index]/page.tsx
@@ -1,0 +1,34 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import {
+  ContainerManagement,
+  ContainerFormData,
+} from "@/components/container-management"
+
+interface PageProps {
+  params: { index: string }
+}
+
+export default function EditContainerPage({ params }: PageProps) {
+  const [data, setData] = useState<ContainerFormData | null>(null)
+
+  useEffect(() => {
+    try {
+      const stored = JSON.parse(localStorage.getItem("contenedores") || "[]")
+      const idx = parseInt(params.index, 10)
+      if (Array.isArray(stored) && stored[idx]) {
+        setData(stored[idx])
+      } else {
+        alert("Contenedor no encontrado.")
+      }
+    } catch {
+      alert("Error al cargar el contenedor.")
+    }
+  }, [params.index])
+
+  if (!data) return null
+
+  return <ContainerManagement initialData={data} index={parseInt(params.index, 10)} />
+}
+

--- a/my-app/app/contenedores/page.tsx
+++ b/my-app/app/contenedores/page.tsx
@@ -11,6 +11,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
+import Link from "next/link"
+import { Button } from "@/components/ui/button"
 
 interface Container {
   serieLetra: string
@@ -170,6 +172,7 @@ export default function ContainersPage() {
                     <th className="py-2 px-3 text-left">Fecha Declaración</th>
                     <th className="py-2 px-3 text-left">Fecha Compra</th>
                     <th className="py-2 px-3 text-left">Notas</th>
+                    <th className="py-2 px-3 text-left">Acciones</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -184,6 +187,13 @@ export default function ContainersPage() {
                       <td className="py-2 px-3">{c.fechaDeclaracion || "-"}</td>
                       <td className="py-2 px-3">{c.fechaCompra || "-"}</td>
                       <td className="py-2 px-3 max-w-[200px] truncate">{c.notas || "-"}</td>
+                      <td className="py-2 px-3">
+                        <Link href={`/contenedores/${index}`}>
+                          <Button variant="outline" size="sm">
+                            Modificar
+                          </Button>
+                        </Link>
+                      </td>
                     </tr>
                   ))}
                 </tbody>


### PR DESCRIPTION
## Summary
- allow modifying and deleting stored containers
- add edit page with delete confirmation

## Testing
- `npm test` *(fails: missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c712f23b0883308c57de06ded6c1fc