### PR TITLE
fix: ensure pdf downloads use filenames

### DIFF
--- a/my-app/app/contenedores/page.tsx
+++ b/my-app/app/contenedores/page.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/ui/select"
 import Link from "next/link"
 import { Button } from "@/components/ui/button"
+import { downloadFile } from "@/lib/utils"
 
 interface Container {
   serieLetra: string
@@ -192,28 +193,36 @@ export default function ContainersPage() {
                       <td className="py-2 px-3">{c.fechaCompra || "-"}</td>
                       <td className="py-2 px-3">
                         {c.declaracionPdf ? (
-                          <a
-                            href={c.declaracionPdf}
-                            target="_blank"
-                            rel="noopener noreferrer"
+                          <button
+                            type="button"
+                            onClick={() =>
+                              downloadFile(
+                                c.declaracionPdf,
+                                `${c.serieLetra}${c.numeroSerie}_declaracion.pdf`,
+                              )
+                            }
                             className="text-primary underline"
                           >
                             Ver
-                          </a>
+                          </button>
                         ) : (
                           "-"
                         )}
                       </td>
                       <td className="py-2 px-3">
                         {c.facturaPdf ? (
-                          <a
-                            href={c.facturaPdf}
-                            target="_blank"
-                            rel="noopener noreferrer"
+                          <button
+                            type="button"
+                            onClick={() =>
+                              downloadFile(
+                                c.facturaPdf,
+                                `${c.serieLetra}${c.numeroSerie}_factura.pdf`,
+                              )
+                            }
                             className="text-primary underline"
                           >
                             Ver
-                          </a>
+                          </button>
                         ) : (
                           "-"
                         )}

--- a/my-app/components/container-management.tsx
+++ b/my-app/components/container-management.tsx
@@ -16,6 +16,7 @@ import {
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { DashboardLayout } from "@/components/dashboard-layout"
 import { Calendar, Upload, Container, FileText } from "lucide-react"
+import { downloadFile } from "@/lib/utils"
 
 export interface ContainerFormData {
   serieLetra: string
@@ -408,14 +409,18 @@ export function ContainerManagement({ initialData, index }: ContainerManagementP
             <div className="space-y-2">
               <Label className="text-sm font-medium">Factura PDF</Label>
               {formData.facturaPdf ? (
-                <a
-                  href={formData.facturaPdf}
-                  target="_blank"
-                  rel="noopener noreferrer"
+                <button
+                  type="button"
+                  onClick={() =>
+                    downloadFile(
+                      formData.facturaPdf,
+                      `${formData.serieLetra}${formData.numeroSerie}_factura.pdf`,
+                    )
+                  }
                   className="text-sm text-primary underline"
                 >
                   Ver PDF
-                </a>
+                </button>
               ) : (
                 <p className="text-sm text-muted-foreground">---------</p>
               )}
@@ -424,14 +429,18 @@ export function ContainerManagement({ initialData, index }: ContainerManagementP
             <div className="space-y-2">
               <Label className="text-sm font-medium">Declaración PDF</Label>
               {formData.declaracionPdf ? (
-                <a
-                  href={formData.declaracionPdf}
-                  target="_blank"
-                  rel="noopener noreferrer"
+                <button
+                  type="button"
+                  onClick={() =>
+                    downloadFile(
+                      formData.declaracionPdf,
+                      `${formData.serieLetra}${formData.numeroSerie}_declaracion.pdf`,
+                    )
+                  }
                   className="text-sm text-primary underline"
                 >
                   Ver PDF
-                </a>
+                </button>
               ) : (
                 <p className="text-sm text-muted-foreground">---------</p>
               )}

--- a/my-app/lib/utils.ts
+++ b/my-app/lib/utils.ts
@@ -4,3 +4,18 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function downloadFile(url?: string, filename?: string) {
+  if (!url) return
+
+  const inferredName = url.startsWith("data:")
+    ? null
+    : url.split("/").pop()
+
+  const link = document.createElement("a")
+  link.href = url
+  link.download = filename ?? inferredName ?? "document.pdf"
+  document.body.appendChild(link)
+  link.click()
+  link.remove()
+}


### PR DESCRIPTION
## Summary
- default to safe filenames when downloading PDFs
- pass container-based names for Declaración and Factura files

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Geist` and `Geist Mono` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68c720f1df908330968c4792d515c690