### PR TITLE
Guardar arriendos y registrar estado del contenedor

### DIFF
--- a/my-app/app/arriendos/page.tsx
+++ b/my-app/app/arriendos/page.tsx
@@ -1,8 +1,36 @@
+"use client"
+
+import { useEffect, useState } from "react"
 import { DashboardLayout } from "@/components/dashboard-layout"
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
 import { Package } from "lucide-react"
+import { downloadFile } from "@/lib/utils"
+
+interface Rental {
+  contenedor: string
+  cliente: string
+  fechaEntrega: string
+  codigoGuia: string
+  fechaRetiro: string
+  facturaPdf?: string
+}
 
 export default function ArriendosPage() {
+  const [rentals, setRentals] = useState<Rental[]>([])
+
+  useEffect(() => {
+    try {
+      const stored = JSON.parse(localStorage.getItem("arriendos") || "[]")
+      if (Array.isArray(stored)) {
+        setRentals(stored)
+      } else {
+        setRentals([])
+      }
+    } catch {
+      setRentals([])
+    }
+  }, [])
+
   return (
     <DashboardLayout breadcrumbs={["Arriendos"]}>
       <Card className="max-w-4xl">
@@ -13,9 +41,48 @@ export default function ArriendosPage() {
           </CardTitle>
         </CardHeader>
         <CardContent>
-          <p className="text-muted-foreground">
-            Aquí se listarán todos los arriendos agregados al sistema.
-          </p>
+          {rentals.length === 0 ? (
+            <p className="text-muted-foreground">No hay arriendos registrados.</p>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="min-w-full text-sm">
+                <thead>
+                  <tr className="border-b">
+                    <th className="py-2 px-3 text-left">Contenedor</th>
+                    <th className="py-2 px-3 text-left">Cliente</th>
+                    <th className="py-2 px-3 text-left">Fecha entrega</th>
+                    <th className="py-2 px-3 text-left">Fecha retiro</th>
+                    <th className="py-2 px-3 text-left">Guía</th>
+                    <th className="py-2 px-3 text-left">Factura</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {rentals.map((r, index) => (
+                    <tr key={index} className="border-b last:border-0">
+                      <td className="py-2 px-3">{r.contenedor}</td>
+                      <td className="py-2 px-3">{r.cliente}</td>
+                      <td className="py-2 px-3">{r.fechaEntrega || "-"}</td>
+                      <td className="py-2 px-3">{r.fechaRetiro || "-"}</td>
+                      <td className="py-2 px-3">{r.codigoGuia || "-"}</td>
+                      <td className="py-2 px-3">
+                        {r.facturaPdf ? (
+                          <button
+                            type="button"
+                            onClick={() => downloadFile(r.facturaPdf, `factura-${r.contenedor}.pdf`)}
+                            className="text-primary hover:underline"
+                          >
+                            Descargar
+                          </button>
+                        ) : (
+                          "-"
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
         </CardContent>
       </Card>
     </DashboardLayout>


### PR DESCRIPTION
## Summary
- Persistir los arriendos en `localStorage` desde el formulario
- Actualizar estado del contenedor a "Arrendado" al guardar
- Mostrar registro de arriendos con descarga de factura

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7334a9ab883309bf03e6be77b4fd2