### PR TITLE
Cambiar etiqueta de factura por guía de despacho en formulario de arriendo

### DIFF
--- a/my-app/components/rental-form.tsx
+++ b/my-app/components/rental-form.tsx
@@ -217,7 +217,7 @@ export function RentalForm() {
       </div>
 
       <div className="space-y-2">
-        <Label className="text-sm font-medium">Ingresar factura (PDF)</Label>
+        <Label className="text-sm font-medium">Ingresar guía de despacho (PDF)</Label>
         <input
           type="file"
           accept="application/pdf"
@@ -240,7 +240,7 @@ export function RentalForm() {
             {facturaFile ? facturaFile.name : "Sin archivos seleccionados"}
           </span>
         </div>
-        <p className="text-xs text-muted-foreground">Subir factura en formato PDF</p>
+        <p className="text-xs text-muted-foreground">Subir guía de despacho en formato PDF</p>
       </div>
 
       <Button type="submit" className="bg-primary hover:bg-primary/90">


### PR DESCRIPTION
## Summary
- Reemplaza la etiqueta de carga de factura por “guía de despacho” en el formulario de arriendo

## Testing
- `npm test` (falla: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c73a5965908330ac75e4f44ba660ec