### PR TITLE
Reemplazar factura por guía de despacho en arriendos

### DIFF
--- a/my-app/app/arriendos/page.tsx
+++ b/my-app/app/arriendos/page.tsx
@@ -12,7 +12,7 @@ interface Rental {
   fechaEntrega: string
   codigoGuia: string
   fechaRetiro: string
-  facturaPdf?: string
+  guiaPdf?: string
 }
 
 export default function ArriendosPage() {
@@ -53,7 +53,7 @@ export default function ArriendosPage() {
                     <th className="py-2 px-3 text-left">Fecha entrega</th>
                     <th className="py-2 px-3 text-left">Fecha retiro</th>
                     <th className="py-2 px-3 text-left">Guía</th>
-                    <th className="py-2 px-3 text-left">Factura</th>
+                    <th className="py-2 px-3 text-left">Guía PDF</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -65,10 +65,10 @@ export default function ArriendosPage() {
                       <td className="py-2 px-3">{r.fechaRetiro || "-"}</td>
                       <td className="py-2 px-3">{r.codigoGuia || "-"}</td>
                       <td className="py-2 px-3">
-                        {r.facturaPdf ? (
+                        {r.guiaPdf ? (
                           <button
                             type="button"
-                            onClick={() => downloadFile(r.facturaPdf, `factura-${r.contenedor}.pdf`)}
+                            onClick={() => downloadFile(r.guiaPdf, `guia-${r.contenedor}.pdf`)}
                             className="text-primary hover:underline"
                           >
                             Descargar

--- a/my-app/components/rental-form.tsx
+++ b/my-app/components/rental-form.tsx
@@ -21,7 +21,7 @@ interface RentalData {
   fechaEntrega: string
   codigoGuia: string
   fechaRetiro: string
-  facturaPdf?: string
+  guiaPdf?: string
 }
 
 export function RentalForm() {
@@ -54,8 +54,8 @@ export function RentalForm() {
     fechaRetiro: "",
   })
 
-  const [facturaFile, setFacturaFile] = useState<File | null>(null)
-  const facturaInputRef = useRef<HTMLInputElement>(null)
+  const [guiaFile, setGuiaFile] = useState<File | null>(null)
+  const guiaInputRef = useRef<HTMLInputElement>(null)
 
   const readFileAsDataURL = (file: File): Promise<string> => {
     return new Promise((resolve, reject) => {
@@ -78,8 +78,8 @@ export function RentalForm() {
     }
 
     const newRental: RentalData = { ...formData }
-    if (facturaFile) {
-      newRental.facturaPdf = await readFileAsDataURL(facturaFile)
+    if (guiaFile) {
+      newRental.guiaPdf = await readFileAsDataURL(guiaFile)
     }
 
     let rentals: RentalData[] = []
@@ -217,12 +217,12 @@ export function RentalForm() {
       </div>
 
       <div className="space-y-2">
-        <Label className="text-sm font-medium">Ingresar factura (PDF)</Label>
+        <Label className="text-sm font-medium">Ingresar guía de despacho (PDF)</Label>
         <input
           type="file"
           accept="application/pdf"
-          ref={facturaInputRef}
-          onChange={(e) => setFacturaFile(e.target.files?.[0] || null)}
+          ref={guiaInputRef}
+          onChange={(e) => setGuiaFile(e.target.files?.[0] || null)}
           className="hidden"
         />
         <div className="flex items-center gap-2">
@@ -231,16 +231,16 @@ export function RentalForm() {
             variant="outline"
             size="sm"
             className="flex items-center gap-2 bg-transparent"
-            onClick={() => facturaInputRef.current?.click()}
+            onClick={() => guiaInputRef.current?.click()}
           >
             <Upload className="h-4 w-4" />
             Seleccionar archivo
           </Button>
           <span className="text-sm text-muted-foreground">
-            {facturaFile ? facturaFile.name : "Sin archivos seleccionados"}
+            {guiaFile ? guiaFile.name : "Sin archivos seleccionados"}
           </span>
         </div>
-        <p className="text-xs text-muted-foreground">Subir factura en formato PDF</p>
+        <p className="text-xs text-muted-foreground">Subir guía de despacho en formato PDF</p>
       </div>
 
       <Button type="submit" className="bg-primary hover:bg-primary/90">


### PR DESCRIPTION
## Summary
- Renombra los campos de factura a guía de despacho en el formulario de arriendos
- Actualiza el listado de arriendos para descargar el PDF de la guía

## Testing
- `npm test` (falla: Missing script: "test")
- `npm run lint`
- `npm run build` (falla: Failed to fetch `Geist` from Google Fonts)

------
https://chatgpt.com/codex/tasks/task_e_68c73a5965908330ac75e4f44ba660ec