### PR TITLE
Add search filter to arriendos table

### DIFF
--- a/my-app/app/arriendos/page.tsx
+++ b/my-app/app/arriendos/page.tsx
@@ -1,8 +1,9 @@
 "use client"
 
-import { useEffect, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { DashboardLayout } from "@/components/dashboard-layout"
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
 import { Package } from "lucide-react"
 import { downloadFile } from "@/lib/utils"
 
@@ -17,6 +18,21 @@ interface Rental {
 
 export default function ArriendosPage() {
   const [rentals, setRentals] = useState<Rental[]>([])
+  const [searchTerm, setSearchTerm] = useState("")
+
+  const filteredRentals = useMemo(() => {
+    const term = searchTerm.trim().toLowerCase()
+
+    if (!term) {
+      return rentals
+    }
+
+    return rentals.filter(
+      (rental) =>
+        rental.contenedor.toLowerCase().includes(term) ||
+        rental.cliente.toLowerCase().includes(term),
+    )
+  }, [rentals, searchTerm])
 
   useEffect(() => {
     try {
@@ -44,44 +60,58 @@ export default function ArriendosPage() {
           {rentals.length === 0 ? (
             <p className="text-muted-foreground">No hay arriendos registrados.</p>
           ) : (
-            <div className="overflow-x-auto">
-              <table className="min-w-full text-sm">
-                <thead>
-                  <tr className="border-b">
-                    <th className="py-2 px-3 text-left">Contenedor</th>
-                    <th className="py-2 px-3 text-left">Cliente</th>
-                    <th className="py-2 px-3 text-left">Fecha entrega</th>
-                    <th className="py-2 px-3 text-left">Fecha retiro</th>
-                    <th className="py-2 px-3 text-left">Guía</th>
-                    <th className="py-2 px-3 text-left">Guía PDF</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {rentals.map((r, index) => (
-                    <tr key={index} className="border-b last:border-0">
-                      <td className="py-2 px-3">{r.contenedor}</td>
-                      <td className="py-2 px-3">{r.cliente}</td>
-                      <td className="py-2 px-3">{r.fechaEntrega || "-"}</td>
-                      <td className="py-2 px-3">{r.fechaRetiro || "-"}</td>
-                      <td className="py-2 px-3">{r.codigoGuia || "-"}</td>
-                      <td className="py-2 px-3">
-                        {r.guiaPdf ? (
-                          <button
-                            type="button"
-                            onClick={() => downloadFile(r.guiaPdf, `guia-${r.contenedor}.pdf`)}
-                            className="text-primary hover:underline"
-                          >
-                            Descargar
-                          </button>
-                        ) : (
-                          "-"
-                        )}
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
+            <>
+              <Input
+                value={searchTerm}
+                onChange={(event) => setSearchTerm(event.target.value)}
+                placeholder="Buscar por contenedor o cliente"
+                className="mb-4"
+              />
+              {filteredRentals.length === 0 ? (
+                <p className="text-muted-foreground">
+                  No se encontraron arriendos para la búsqueda.
+                </p>
+              ) : (
+                <div className="overflow-x-auto">
+                  <table className="min-w-full text-sm">
+                    <thead>
+                      <tr className="border-b">
+                        <th className="py-2 px-3 text-left">Contenedor</th>
+                        <th className="py-2 px-3 text-left">Cliente</th>
+                        <th className="py-2 px-3 text-left">Fecha entrega</th>
+                        <th className="py-2 px-3 text-left">Fecha retiro</th>
+                        <th className="py-2 px-3 text-left">Guía</th>
+                        <th className="py-2 px-3 text-left">Guía PDF</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {filteredRentals.map((r, index) => (
+                        <tr key={index} className="border-b last:border-0">
+                          <td className="py-2 px-3">{r.contenedor}</td>
+                          <td className="py-2 px-3">{r.cliente}</td>
+                          <td className="py-2 px-3">{r.fechaEntrega || "-"}</td>
+                          <td className="py-2 px-3">{r.fechaRetiro || "-"}</td>
+                          <td className="py-2 px-3">{r.codigoGuia || "-"}</td>
+                          <td className="py-2 px-3">
+                            {r.guiaPdf ? (
+                              <button
+                                type="button"
+                                onClick={() => downloadFile(r.guiaPdf, `guia-${r.contenedor}.pdf`)}
+                                className="text-primary hover:underline"
+                              >
+                                Descargar
+                              </button>
+                            ) : (
+                              "-"
+                            )}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </>
           )}
         </CardContent>
       </Card>


### PR DESCRIPTION
## Summary
- add search state and memoized filtering for arriendos rentals
- render a search input above the table and show a message when no results match

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9df3b40a88330821c6eefad97afa7