### PR TITLE
Enforce required field validation in forms

### DIFF
--- a/my-app/components/client-form.tsx
+++ b/my-app/components/client-form.tsx
@@ -43,6 +43,25 @@ export function ClientForm({ initialData, index }: ClientFormProps) {
   const handleSubmit = (event: React.FormEvent) => {
     event.preventDefault()
 
+    const requiredFields: { key: keyof typeof formData; label: string }[] = [
+      { key: "nombre", label: "Razón Social / Nombre Completo" },
+      { key: "tipo", label: "Tipo de Cliente" },
+      { key: "documento", label: "Documento de Identidad (RUT/RUC)" },
+      { key: "email", label: "Correo Electrónico" },
+      { key: "telefono", label: "Teléfono" },
+      { key: "contacto", label: "Contacto" },
+      { key: "ciudad", label: "Ciudad" },
+    ]
+
+    const missingFields = requiredFields
+      .filter(({ key }) => formData[key].trim() === "")
+      .map(({ label }) => label)
+
+    if (missingFields.length > 0) {
+      alert(`¡¡ALERTA te falta escribir : ${missingFields.join(", ")}!!`)
+      return
+    }
+
     let existing: Cliente[] = []
     try {
       const stored = localStorage.getItem("clientes")

--- a/my-app/components/container-management.tsx
+++ b/my-app/components/container-management.tsx
@@ -146,16 +146,49 @@ export function ContainerManagement({ initialData, index }: ContainerManagementP
       digitoControl: digitoError,
     }
     setErrors(newErrors)
-    if (serieError || numeroError || digitoError) {
-      return
-    }
+
     const { estado, patio } = formData
     const requiresPatio =
       estado === "Disponible" || estado === "Mantenimiento" || estado === "Rancho"
-    if (requiresPatio && !patio) {
-      alert(
-        "Debe seleccionar un patio cuando el contenedor está Disponible, en Mantenimiento o en Rancho",
-      )
+
+    const missingFields: string[] = []
+    if (formData.serieLetra.trim() === "") {
+      missingFields.push("Serie letra")
+    }
+    if (formData.numeroSerie.trim() === "") {
+      missingFields.push("Número serie")
+    }
+    if (formData.digitoControl.trim() === "") {
+      missingFields.push("Dígito de control")
+    }
+    if (formData.tipo.trim() === "") {
+      missingFields.push("Tipo")
+    }
+    if (formData.estado.trim() === "") {
+      missingFields.push("Estado")
+    }
+    if (requiresPatio && patio.trim() === "") {
+      missingFields.push("Patio")
+    }
+    if (formData.numeroDeclaracion.trim() === "") {
+      missingFields.push("Nº Declaración de Importación")
+    }
+    if (formData.fechaDeclaracion.trim() === "") {
+      missingFields.push("Fecha Declaración de Importación")
+    }
+    if (formData.fechaCompra.trim() === "") {
+      missingFields.push("Fecha de compra")
+    }
+    if (formData.notas.trim() === "") {
+      missingFields.push("Notas")
+    }
+
+    if (missingFields.length > 0) {
+      alert(`¡¡ALERTA te falta escribir : ${missingFields.join(", ")}!!`)
+      return
+    }
+
+    if (serieError || numeroError || digitoError) {
       return
     }
     if (estado === "Arrendado" && patio) {

--- a/my-app/components/rental-form.tsx
+++ b/my-app/components/rental-form.tsx
@@ -107,8 +107,20 @@ export function RentalForm() {
 
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault()
-    if (!formData.contenedor || !formData.cliente) {
-      alert("Debe seleccionar contenedor y cliente")
+    const requiredFields: { key: keyof RentalData; label: string }[] = [
+      { key: "contenedor", label: "Contenedor" },
+      { key: "cliente", label: "Cliente" },
+      { key: "fechaEntrega", label: "Fecha de entrega" },
+      { key: "codigoGuia", label: "Código guía despacho" },
+      { key: "fechaRetiro", label: "Fecha de retiro" },
+    ]
+
+    const missingFields = requiredFields
+      .filter(({ key }) => (formData[key] ?? "").trim() === "")
+      .map(({ label }) => label)
+
+    if (missingFields.length > 0) {
+      alert(`¡¡ALERTA te falta escribir : ${missingFields.join(", ")}!!`)
       return
     }
 


### PR DESCRIPTION
## Summary
- block guardar en el formulario de clientes cuando faltan datos y mostrar la alerta solicitada
- impedir que el formulario de contenedores se guarde sin completar todos los campos requeridos y reutilizar el mensaje de alerta
- validar que el formulario de arriendos tenga cada campo obligatorio antes de almacenarlo

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca1a53f8d08330947054363ed9caf8