### PR TITLE
Require PDF uploads for container records

### DIFF
--- a/my-app/components/container-management.tsx
+++ b/my-app/components/container-management.tsx
@@ -152,6 +152,8 @@ export function ContainerManagement({ initialData, index }: ContainerManagementP
       estado === "Disponible" || estado === "Mantenimiento" || estado === "Rancho"
 
     const missingFields: string[] = []
+    const hasDeclaracionPdf = Boolean(formData.declaracionPdf) || !!declaracionFile
+    const hasFacturaPdf = Boolean(formData.facturaPdf) || !!facturaFile
     if (formData.serieLetra.trim() === "") {
       missingFields.push("Serie letra")
     }
@@ -178,6 +180,12 @@ export function ContainerManagement({ initialData, index }: ContainerManagementP
     }
     if (formData.fechaCompra.trim() === "") {
       missingFields.push("Fecha de compra")
+    }
+    if (!hasDeclaracionPdf) {
+      missingFields.push("Declaración de Importación (PDF)")
+    }
+    if (!hasFacturaPdf) {
+      missingFields.push("Factura de compra (PDF)")
     }
     if (missingFields.length > 0) {
       alert(`¡¡ALERTA te falta escribir : ${missingFields.join(", ")}!!`)


### PR DESCRIPTION
## Summary
- add validation in the container form to ensure declaration and invoice PDFs are provided
- surface an alert when either PDF is missing before saving the container data

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca1ee9b120833087137e12afeed6bc