### PR TITLE
Format date display as day-month-year

### DIFF
--- a/my-app/app/arriendos/page.tsx
+++ b/my-app/app/arriendos/page.tsx
@@ -5,7 +5,7 @@ import { DashboardLayout } from "@/components/dashboard-layout"
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { Package } from "lucide-react"
-import { downloadFile } from "@/lib/utils"
+import { downloadFile, formatDateDisplay } from "@/lib/utils"
 
 interface Rental {
   contenedor: string
@@ -85,28 +85,33 @@ export default function ArriendosPage() {
                       </tr>
                     </thead>
                     <tbody>
-                      {filteredRentals.map((r, index) => (
-                        <tr key={index} className="border-b last:border-0">
-                          <td className="py-2 px-3">{r.contenedor}</td>
-                          <td className="py-2 px-3">{r.cliente}</td>
-                          <td className="py-2 px-3">{r.fechaEntrega || "-"}</td>
-                          <td className="py-2 px-3">{r.fechaRetiro || "-"}</td>
-                          <td className="py-2 px-3">{r.codigoGuia || "-"}</td>
-                          <td className="py-2 px-3">
-                            {r.guiaPdf ? (
-                              <button
-                                type="button"
-                                onClick={() => downloadFile(r.guiaPdf, `guia-${r.contenedor}.pdf`)}
-                                className="text-primary hover:underline"
-                              >
-                                Descargar
-                              </button>
-                            ) : (
-                              "-"
-                            )}
-                          </td>
-                        </tr>
-                      ))}
+                      {filteredRentals.map((r, index) => {
+                        const fechaEntrega = formatDateDisplay(r.fechaEntrega)
+                        const fechaRetiro = formatDateDisplay(r.fechaRetiro)
+
+                        return (
+                          <tr key={index} className="border-b last:border-0">
+                            <td className="py-2 px-3">{r.contenedor}</td>
+                            <td className="py-2 px-3">{r.cliente}</td>
+                            <td className="py-2 px-3">{fechaEntrega || "-"}</td>
+                            <td className="py-2 px-3">{fechaRetiro || "-"}</td>
+                            <td className="py-2 px-3">{r.codigoGuia || "-"}</td>
+                            <td className="py-2 px-3">
+                              {r.guiaPdf ? (
+                                <button
+                                  type="button"
+                                  onClick={() => downloadFile(r.guiaPdf, `guia-${r.contenedor}.pdf`)}
+                                  className="text-primary hover:underline"
+                                >
+                                  Descargar
+                                </button>
+                              ) : (
+                                "-"
+                              )}
+                            </td>
+                          </tr>
+                        )
+                      })}
                     </tbody>
                   </table>
                 </div>

--- a/my-app/app/contenedores/page.tsx
+++ b/my-app/app/contenedores/page.tsx
@@ -13,7 +13,7 @@ import {
 } from "@/components/ui/select"
 import Link from "next/link"
 import { Button } from "@/components/ui/button"
-import { downloadFile } from "@/lib/utils"
+import { downloadFile, formatDateDisplay } from "@/lib/utils"
 
 interface Container {
   serieLetra: string
@@ -185,6 +185,8 @@ export default function ContainersPage() {
                   {filteredContainers.map((c, index) => {
                     const serieCodigo = `${c.serieLetra}${c.numeroSerie}${c.digitoControl ?? ""}`
                     const archivoBase = serieCodigo || "contenedor"
+                    const fechaDeclaracion = formatDateDisplay(c.fechaDeclaracion)
+                    const fechaCompra = formatDateDisplay(c.fechaCompra)
                     return (
                       <tr key={index} className="border-b last:border-0">
                         <td className="py-2 px-3 font-medium">{serieCodigo}</td>
@@ -193,8 +195,8 @@ export default function ContainersPage() {
                         <td className="py-2 px-3">{c.patio || "-"}</td>
                         <td className="py-2 px-3">{c.proveedor || "-"}</td>
                         <td className="py-2 px-3">{c.numeroDeclaracion || "-"}</td>
-                        <td className="py-2 px-3">{c.fechaDeclaracion || "-"}</td>
-                        <td className="py-2 px-3">{c.fechaCompra || "-"}</td>
+                        <td className="py-2 px-3">{fechaDeclaracion || "-"}</td>
+                        <td className="py-2 px-3">{fechaCompra || "-"}</td>
                         <td className="py-2 px-3">
                           {c.declaracionPdf ? (
                             <button

--- a/my-app/lib/utils.ts
+++ b/my-app/lib/utils.ts
@@ -19,3 +19,27 @@ export function downloadFile(url?: string, filename?: string) {
   link.click()
   link.remove()
 }
+
+export function formatDateDisplay(dateString?: string | null) {
+  if (!dateString) {
+    return ""
+  }
+
+  const [normalized] = dateString.split("T")
+  const parts = normalized.split("-")
+
+  if (parts.length !== 3) {
+    return dateString
+  }
+
+  const [year, month, day] = parts
+
+  if (!year || !month || !day) {
+    return dateString
+  }
+
+  const dayPadded = day.padStart(2, "0")
+  const monthPadded = month.padStart(2, "0")
+
+  return `${dayPadded}-${monthPadded}-${year}`
+}


### PR DESCRIPTION
## Summary
- add a reusable utility to present stored dates as day-month-year
- update container and rental listings to show formatted dates

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca2016aa888330bb9f0b756cff5173