### PR TITLE
Allow saving containers without mandatory PDFs

### DIFF
--- a/my-app/components/container-management.tsx
+++ b/my-app/components/container-management.tsx
@@ -80,10 +80,6 @@ export function ContainerManagement({ initialData, index }: ContainerManagementP
     initialData ? sanitizeInitialData(initialData) : createEmptyFormState(),
   )
   const [errors, setErrors] = useState(createInitialErrors)
-  const [fileErrors, setFileErrors] = useState({
-    declaracion: false,
-    factura: false,
-  })
 
   const [declaracionFile, setDeclaracionFile] = useState<File | null>(null)
   const [facturaFile, setFacturaFile] = useState<File | null>(null)
@@ -106,12 +102,8 @@ export function ContainerManagement({ initialData, index }: ContainerManagementP
   const resetForm = () => {
     setFormData(createEmptyFormState())
     setErrors(createInitialErrors())
-    setFileErrors({ declaracion: false, factura: false })
     clearFileSelections()
   }
-
-  const hasDeclaracionPdfSelected = Boolean(formData.declaracionPdf) || !!declaracionFile
-  const hasFacturaPdfSelected = Boolean(formData.facturaPdf) || !!facturaFile
 
   const router = useRouter()
   const isEditing = typeof index === "number" && !!initialData
@@ -172,17 +164,11 @@ export function ContainerManagement({ initialData, index }: ContainerManagementP
 
   const handleDeclaracionFileChange = (file: File | null) => {
     setDeclaracionFile(file)
-    if (file) {
-      setFileErrors((prev) => ({ ...prev, declaracion: false }))
-    }
     setSuccessMessage(null)
   }
 
   const handleFacturaFileChange = (file: File | null) => {
     setFacturaFile(file)
-    if (file) {
-      setFileErrors((prev) => ({ ...prev, factura: false }))
-    }
     setSuccessMessage(null)
   }
 
@@ -212,13 +198,6 @@ export function ContainerManagement({ initialData, index }: ContainerManagementP
         estado === "Disponible" || estado === "Mantenimiento" || estado === "Rancho"
 
       const missingFields: string[] = []
-      const hasDeclaracionPdf = hasDeclaracionPdfSelected
-      const hasFacturaPdf = hasFacturaPdfSelected
-      setFileErrors({
-        declaracion: !hasDeclaracionPdf,
-        factura: !hasFacturaPdf,
-      })
-
       if (formData.serieLetra.trim() === "") {
         missingFields.push("Serie letra")
       }
@@ -245,12 +224,6 @@ export function ContainerManagement({ initialData, index }: ContainerManagementP
       }
       if (formData.fechaCompra.trim() === "") {
         missingFields.push("Fecha de compra")
-      }
-      if (!hasDeclaracionPdf) {
-        missingFields.push("Declaración de Importación (PDF)")
-      }
-      if (!hasFacturaPdf) {
-        missingFields.push("Factura de compra (PDF)")
       }
       if (missingFields.length > 0) {
         alert(`¡¡ALERTA te falta escribir : ${missingFields.join(", ")}!!`)
@@ -554,7 +527,6 @@ export function ContainerManagement({ initialData, index }: ContainerManagementP
                 <div className="space-y-2">
                   <Label htmlFor="declaracion-pdf" className="text-sm font-medium">
                     Declaración de Importación (PDF)
-                    <span className="ml-1 text-destructive">*</span>
                   </Label>
                   <input
                     id="declaracion-pdf"
@@ -563,7 +535,6 @@ export function ContainerManagement({ initialData, index }: ContainerManagementP
                     ref={declaracionInputRef}
                     onChange={(e) => handleDeclaracionFileChange(e.target.files?.[0] || null)}
                     className="hidden"
-                    aria-required="true"
                   />
                   <div className="flex items-center gap-2">
                     <Button
@@ -584,12 +555,9 @@ export function ContainerManagement({ initialData, index }: ContainerManagementP
                         : "Sin archivos seleccionados"}
                     </span>
                   </div>
-                  <p className="text-xs text-muted-foreground">Subir la Declaración de Importación en PDF</p>
-                  {fileErrors.declaracion && (
-                    <p className="text-sm text-destructive">
-                      Debes adjuntar la Declaración de Importación en PDF.
-                    </p>
-                  )}
+                  <p className="text-xs text-muted-foreground">
+                    Subir la Declaración de Importación en PDF (opcional)
+                  </p>
                 </div>
 
                 <div className="space-y-2">
@@ -611,7 +579,6 @@ export function ContainerManagement({ initialData, index }: ContainerManagementP
                 <div className="space-y-2">
                   <Label htmlFor="factura-pdf" className="text-sm font-medium">
                     Ingresar factura (PDF)
-                    <span className="ml-1 text-destructive">*</span>
                   </Label>
                   <input
                     id="factura-pdf"
@@ -620,7 +587,6 @@ export function ContainerManagement({ initialData, index }: ContainerManagementP
                     ref={facturaInputRef}
                     onChange={(e) => handleFacturaFileChange(e.target.files?.[0] || null)}
                     className="hidden"
-                    aria-required="true"
                   />
                   <div className="flex items-center gap-2">
                     <Button
@@ -641,12 +607,9 @@ export function ContainerManagement({ initialData, index }: ContainerManagementP
                         : "Sin archivos seleccionados"}
                     </span>
                   </div>
-                  <p className="text-xs text-muted-foreground">Subir factura de compra en formato PDF</p>
-                  {fileErrors.factura && (
-                    <p className="text-sm text-destructive">
-                      Debes adjuntar la factura de compra en PDF.
-                    </p>
-                  )}
+                  <p className="text-xs text-muted-foreground">
+                    Subir factura de compra en formato PDF (opcional)
+                  </p>
                 </div>
 
                 <div className="space-y-4">


### PR DESCRIPTION
## Summary
- make the PDF attachments optional when saving a container so the record can always be stored in the register
- remove the blocking validation and error badges tied to missing Declaration and Invoice PDFs while keeping the upload helpers available

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca2ffb350083308b2d65140eb2d978