### PR TITLE
Handle localStorage quota errors when saving containers

### DIFF
--- a/my-app/components/container-management.tsx
+++ b/my-app/components/container-management.tsx
@@ -298,7 +298,26 @@ export function ContainerManagement({ initialData, index }: ContainerManagementP
       } else {
         stored.push(updatedData)
       }
-      localStorage.setItem("contenedores", JSON.stringify(stored))
+
+      try {
+        localStorage.setItem("contenedores", JSON.stringify(stored))
+      } catch (error) {
+        console.error("Error al guardar contenedor en localStorage", error)
+
+        const quotaExceeded =
+          error instanceof DOMException &&
+          (error.name === "QuotaExceededError" ||
+            error.name === "NS_ERROR_DOM_QUOTA_REACHED" ||
+            error.code === 22 ||
+            error.code === 1014)
+
+        const message = quotaExceeded
+          ? "No se pudo guardar el contenedor porque el almacenamiento del navegador está lleno. Elimina archivos o registros antiguos e inténtalo nuevamente."
+          : "Ocurrió un error inesperado al guardar el contenedor. Inténtalo nuevamente."
+
+        alert(message)
+        return false
+      }
 
       if (mode === "redirect") {
         router.push("/contenedores")


### PR DESCRIPTION
## Summary
- wrap the container creation storage step in a try/catch to handle quota errors from localStorage
- surface a clear alert when the browser storage is full and log unexpected failures

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cae9b554c483308056cd6e206f62ef